### PR TITLE
Stud 287 fix css issues displayed on elements found in teams page

### DIFF
--- a/src/components/modals/CreateTeam.js
+++ b/src/components/modals/CreateTeam.js
@@ -151,12 +151,12 @@ const TextField = styled.TextInput`
     border-bottom-left-radius: 100;
     border-top-right-radius: 100;
     border-bottom-right-radius: 100;
-    width: 60%;
-    padding-left: ${theme.SPACING_XSMALL};
+    width: 55%;
+    padding-left: ${theme.SPACING_SMALL};
 `
 
 const NumberField = styled(TextField)`
-    width: 30%;
+    width: 15%;
 `
 
 const StyledFlexBox = styled.View`

--- a/src/containers/ListContainer.js
+++ b/src/containers/ListContainer.js
@@ -185,7 +185,7 @@ flex-direction:column
 
 const SearchContainer = styled.View`
 display:flex;
-flex-direction:row
+flex-direction:row;
 `
 
 const CustomText = styled.TextInput`
@@ -197,6 +197,7 @@ const SearchField = styled(CustomText)`
 `
 const FilterButton = styled.TouchableOpacity`
   align-items: center;
+  margin-bottom: 5;
 `;
 
 const SearchButton = styled(FilterButton)`
@@ -253,15 +254,15 @@ const ClassLabel = styled.View`
 
 const LabelClassName = styled.Text`
   color: white;
-  align-items: center;
   font-family: ${theme.FONT_SEMIBOLD};
   letter-spacing: ${theme.LETTER_SPACING_SMALL};
 `;
 
 const LabelIcon = styled.Image`
   tintColor: #ffff;
-  width: 10;
-  height: 10;
+  width: 13;
+  height: 14;
+  margin-left: 3px;
 `;
 
 const IconTag = styled.View`


### PR DESCRIPTION
There are components in the Team section which require some small adjustments:

  - The X icon on the Label that is displayed after entering class name in Filter section, needs to be aligned. 
  - The Create Team modal’s placeholders are to be adjusted in width to fit within the frame. 
  - TextInput of both Filter and Search are vertically misaligned to their respective icons. 

BEFORE 
![image](https://user-images.githubusercontent.com/55245612/160268860-70424ad9-3e0b-46b2-8b0c-46c4819ec640.png)
![image](https://user-images.githubusercontent.com/55245612/160268602-1bb2f273-d0d4-49d1-98fa-d42bd3f03732.png)

AFTER 
![image](https://user-images.githubusercontent.com/55245612/160268823-09922a7e-c575-43a3-8a33-42b0adec6311.png)
![image](https://user-images.githubusercontent.com/55245612/160268833-bf35b5c8-c12d-48cb-9504-c3d184af0c6e.png)

