### PR TITLE
fill feed with readonly: enrolled classes, current teams, team requests

### DIFF
--- a/src/components/feed/TeamItem.js
+++ b/src/components/feed/TeamItem.js
@@ -1,0 +1,63 @@
+import React, { Component } from 'react';
+import { Platform } from 'react-native';
+import styled from 'styled-components';
+import theme from '../../styles/theme.style.js';
+import MainContainer from '../../containers/MainContainer.js';
+import { Title, Subtitle } from '../../containers/TextContainer.js';
+
+class TeamItem extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            isToggled: false
+        };
+
+        this.onToggle = this.onToggle.bind(this)
+    }
+
+    onToggle() {
+        this.setState({isToggled: !this.state.isToggled});
+    }
+
+    render() {
+        return (
+            <MainContainer
+              marginBottom={10}
+                isTouchable
+                isElevated
+                backgroundColor={this.props.backgroundColor} >
+                <Header>
+                    <Subtitle>{this.props.classNumber}</Subtitle>
+                    <NotificationSwitch
+                        trackColor={{ false: '#ffffff50', true: '#00000010' }}
+                        thumbColor={this.state.isToggled ? theme.COLOR_GREEN : theme.COLOR_WHITE}
+                        ios_backgroundColor={this.props.backgroundColor}
+                        onChange={this.onToggle}
+                        value={this.state.isToggled}
+                    />
+                </Header>
+                <Title>{this.props.roomName}</Title>
+            </MainContainer>
+        );
+    }
+}
+
+//STYLED-COMPONENTS
+const Header = styled.View `
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+`
+
+const NotificationSwitch = styled.Switch `
+    /* In order to remove switch padding from Android only */
+    margin-vertical: ${Platform.OS === 'ios' ? 0 : -13};
+    margin-horizontal: ${Platform.OS === 'ios' ? 0 : -10};
+    padding-top: 0;
+    min-width: 0;
+    min-height: 0;
+`;
+
+export default TeamItem;

--- a/src/components/feed/TeamRequestItem.js
+++ b/src/components/feed/TeamRequestItem.js
@@ -1,0 +1,84 @@
+import React, { Component, } from 'react';
+import styled from 'styled-components';
+import theme from '../../styles/theme.style.js';
+import MainContainer from '../../containers/MainContainer.js';
+import Label from '../Label.js';
+
+class TeamRequestItem extends Component {
+  constructor(props) {
+    super(props);
+  };
+
+  setTeamFormationColor(status) {
+    let color;
+
+    switch (status) {
+      case 'available':
+        color = theme.COLOR_GREEN;
+        break;
+      case 'pending':
+        color = theme.COLOR_YELLOW;
+        break;
+      case 'taken':
+        color = theme.COLOR_RED;
+        break;
+      default:
+        color = theme.COLOR_GRAY;
+    }
+
+    return color;
+  }
+
+  render() {
+    return (
+      <MainContainer marginBottom={10} isElevated>
+        <ContentContainer>
+          <ContentLHS>
+            {this.props.roomName && <Label isReadOnly labelColor={this.props.labelColor}>{this.props.roomName}</Label>}
+            <ParticipantName>{this.props.participantName}</ParticipantName>
+          </ContentLHS>
+          <ContentRHS>
+            <TeamFormationStatus statusColor={this.setTeamFormationColor(this.props.userTeamStatus)} />
+          </ContentRHS>
+        </ContentContainer>
+      </MainContainer>
+    );
+  }
+}
+
+const ContentContainer = styled.View`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+`;
+
+const ContentLHS = styled.View`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+
+`;
+
+const ContentRHS = styled.View`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const ParticipantName = styled.Text`
+  font-family: ${theme.FONT_SEMIBOLD};
+  font-size: ${theme.FONT_SIZE_SLIGHT_LARGE};
+  text-transform: capitalize;
+`;
+
+const TeamFormationStatus = styled.TouchableOpacity`
+  width: 10;
+  height: 10;
+  border-radius: 5;
+  background: ${props => props.statusColor};
+`;
+
+export default TeamRequestItem;

--- a/src/screens/Feed.js
+++ b/src/screens/Feed.js
@@ -83,7 +83,7 @@ class Feed extends Component {
   }
 
   getColor(name) {
-    name = name + ""
+    name = name
     String.prototype.hashCode = function() {
         var hash = 0;
         for (var i = 0; i < this.length; i++) {

--- a/src/screens/Feed.js
+++ b/src/screens/Feed.js
@@ -1,42 +1,193 @@
 import React, { Component } from "react";
-import PropTypes from 'prop-types';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import axios from 'axios';
 import styled from 'styled-components';
-import { StyleSheet, Text, View, Image } from 'react-native';
+import { View, ScrollView, Text } from 'react-native';
 import theme from '../styles/theme.style.js';
-import MainContainer from '../containers/MainContainer.js';
 import ScreenContainer from '../containers/ScreenContainer.js';
-import { TextBody, Title, Subtitle } from '../containers/TextContainer.js';
-import ParticipantListItem from "../components/ParticipantListItem.js";
-import MessageIcons from "../components/MessageIcons.js";
-import MessageBubble from '../components/MessageBubble.js';
-import TeamListItem from '../components/TeamListItem.js';
-import EyesGif from '../assets/images/eyes-looking.gif';
+import TeamRequestItem from '../components/feed/TeamRequestItem.js';
+import TeamItem from '../components/feed/TeamItem.js';
 
+// for testing w/out login
+let config = {
+  headers: {
+      'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaXJzdF9uYW1lIjoiU3RlbGxhIiwibGFzdF9uYW1lIjoiTmd1eWVuIiwiZXhwIjoxNjM3ODg2OTkyLCJpc3MiOiIwZWE1MmFhZi1jMmRiLTRkZTctYjAxNC03N2MxZDI2YjVlZWEifQ.JoLJUdi6rLAAhyDXbaUWoGvS_W1x2PyrdDjksjoL_I4'
+  }
+}
 
 class Feed extends Component {
   constructor(props) {
     super(props);
+
+    this.state = {
+      currentUserData: {},
+      rooms: [],
+      userID: ''
+    }
+
+    this.getCurrentUser = this.getCurrentUser.bind(this);
+    this.getChatRooms = this.getChatRooms.bind(this);
   }
 
-  // Write functions here
+  getConfig = (token) => {
+    return {
+        headers: {
+            'Authorization': `Bearer ${token}`
+        }
+    }
+  }
+
+  async getCurrentUser() {
+        let userID
+        let token
+        try {
+          userID = await AsyncStorage.getItem("userID")
+          token = await AsyncStorage.getItem("token")
+        } catch (err) {
+          console.log(err)
+        }
+
+    axios
+        .get(`http://real.encs.concordia.ca/profile/api/student/${userID}`, this.getConfig(token))
+        // .get(`http://real.encs.concordia.ca/profile/api/student/${userID}`, config) // for testing w/out login
+        .then(response => { this.setState({ currentUserData: response.data, userID: userID }) })
+        .catch(err => console.log(err))
+  }
+
+  async getChatRooms() {
+    let token
+    try {
+      token = await AsyncStorage.getItem("token")
+    } catch (err) {
+      console.log(err)
+    }
+
+    axios
+        .get(`http://real.encs.concordia.ca/chat/api/rooms`, this.getConfig(token)) // w/ login
+        // .get(`http://real.encs.concordia.ca/chat/api/rooms`, config) // for testing w/out login
+        .then(response => {this.setState({ rooms: response.data.Rooms })})
+        .catch( error => {
+          console.log(error)
+          console.log(error.message)
+          console.log(error.response.data);
+          console.log(error.response.status);
+          console.log(error.response.headers);
+          console.log(error.config)
+        })
+  }
+
+  // only called on FIRST render
+  componentDidMount() {
+      this.getCurrentUser();
+      this.getChatRooms();
+  }
+
+  getColor(name) {
+    name = name + ""
+    String.prototype.hashCode = function() {
+        var hash = 0;
+        for (var i = 0; i < this.length; i++) {
+            var char = this.charCodeAt(i);
+            hash = ((hash<<5)-hash)+char;
+            hash = hash & hash; // Convert to 32bit integer
+        }
+        return hash;
+    }
+
+    let colors = [theme.COLOR_PURPLE,
+    theme.COLOR_BLUE,
+    theme.COLOR_YELLOW,
+    theme.COLOR_GREEN,
+    theme.COLOR_RED,
+    theme.COLOR_ORANGE,
+    theme.COLOR_GRAY]
+    return colors[Math.abs(name.hashCode() % 7)]
+  }
 
   render() {
+    let displayEnrolledClasses = this.state.currentUserData.current_classes?.map((enrolledClass) => {
+      return (
+          <EnrolledClassLabel backgroundColor={this.getColor(enrolledClass)} isReadOnly stacked>
+              <ClassTitle>{enrolledClass}</ClassTitle>
+          </EnrolledClassLabel>
+      )
+    });
+
+    let displayTeams = this.state.rooms.map((room) => {
+      return (
+        <TeamItem
+          backgroundColor={this.getColor(room.class)}
+          classNumber={room.class}
+          roomName={room.name}
+          numberParticipants={room.students.length} />
+      )
+    });
+
+    let displayTeamRequests = this.state.rooms.map((room) => {
+      return (
+        room.students.map(student => {
+          if (this.state.userID === room.admin.id && student.isPending) {
+            return (
+              <TeamRequestItem
+                roomName={room.name}
+                class={room.class}
+                participantName={student.first_name}
+                labelColor={this.getColor(room.class)}
+                userTeamStatus={student.isPending ? 'pending' : ''}
+              />
+            )
+          }
+        })
+      )
+    });
+
     return (
-      <ScreenContainer screenTitle="Feed" >
-      <View><Image source={EyesGif} style={styles.gif} /></View>
+      <ScreenContainer screenTitle="Feed">
+        <FeedSection marginTop={23}>
+          <FeedSectionTitle>Enrolled Classes</FeedSectionTitle>
+          <ScrollView horizontal marginTop={10}>
+            {displayEnrolledClasses}
+          </ScrollView>
+        </FeedSection>
+        <FeedSection marginTop={40}>
+          <FeedSectionTitle>Recent Team Conversations</FeedSectionTitle>
+          <ScrollView height={150} marginTop={10} nestedScrollEnabled={true}>
+            {displayTeams}
+          </ScrollView>
+        </FeedSection>
+        <FeedSection marginTop={40}>
+          <FeedSectionTitle>Team Requests Status</FeedSectionTitle>
+          <ScrollView height={150} marginTop={10} nestedScrollEnabled={true}>
+            {displayTeamRequests}
+          </ScrollView>
+        </FeedSection>
+        <View height={110}></View>
       </ScreenContainer>
     );
   }
 }
 
-const styles = StyleSheet.create({
-  gif: {
-    width: 200,
-    height: 100,
-    margin: 100,
-    marginLeft:'auto',
-    marginRight:'auto'
-  }
-});
+const FeedSection = styled.View `
+`
+
+const FeedSectionTitle = styled.Text `
+  text-transform: uppercase;
+  font-family: ${theme.FONT_BOLD};
+  font-size: ${theme.FONT_SIZE_MEDIUM};
+  letter-spacing: ${theme.LETTER_SPACING_LARGE};
+`
+
+const EnrolledClassLabel = styled.View`
+  width: 99;
+  height:103;
+  border-radius:10;
+  margin-horizontal:7;
+  justify-content: center;
+  align-items:center;
+`;
+
+const ClassTitle = styled(FeedSectionTitle) `
+  font-size: ${theme.FONT_SIZE_SLIGHT_MEDIUM};
+`
 
 export default Feed;


### PR DESCRIPTION
In this PR, the Feed.js screen is filled with the user's enrolled classes, the current teams and pending join requests to their teams (shows when they are the admin).
Each section in the Feed is scrollable: 
- Enrolled classes scrollable horizontal
- Current Team Conversations vertical
- Pending Requests vertical

Thanks to Zubair, the colors for each class will be the same, as seen in each feed section.

<pre> Figma Original:                                              Actual: 
<img src="https://user-images.githubusercontent.com/43888017/160957505-d2098c16-ee78-4e77-a910-6aea531104f7.png" width="300" /> <img src="https://user-images.githubusercontent.com/43888017/160957600-eadf94ed-44dc-4796-a2ea-98e01c75a6d7.png" width="290" />
 <pre>
